### PR TITLE
Query Next Records URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,38 +345,37 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-task",
  "pin-project-lite",
@@ -1070,6 +1080,7 @@ name = "rustforce"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "cargo-license",
  "env_logger",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 
 [dependencies]
 
+async-recursion = "1"
 reqwest = { version = "0.11.4", features = ["json"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"

--- a/src/client.rs
+++ b/src/client.rs
@@ -243,11 +243,11 @@ impl Client {
             if !json.done {
                 let next_records_url = json.next_records_url.as_ref().unwrap();
                 let mut recursive_json: QueryResponse<T> = self.query(&next_records_url).await?;
-                recursive_json.records.append(&mut json.records);
-                Ok(recursive_json)
-            } else {
-                Ok(json)
+                json.records.append(&mut recursive_json.records);
+                json.next_records_url = recursive_json.next_records_url;
+                json.done = recursive_json.done;
             }
+            Ok(json)
         } else {
             Err(Error::ErrorResponses(res.json().await?))
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -242,9 +242,9 @@ impl Client {
             let mut json: QueryResponse<T> = res.json().await?;
             if !json.done {
                 let next_records_url = json.next_records_url.as_ref().unwrap();
-                let mut recursirve_json: QueryResponse<T> = self.query(&next_records_url).await?;
-                recursirve_json.records.append(&mut json.records);
-                Ok(recursirve_json)
+                let mut recursive_json: QueryResponse<T> = self.query(&next_records_url).await?;
+                recursive_json.records.append(&mut json.records);
+                Ok(recursive_json)
             } else {
                 Ok(json)
             }

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 pub struct QueryResponse<T> {
     pub total_size: i32,
     pub done: bool,
+    pub next_records_url: Option<String>,
     pub records: Vec<T>,
 }
 


### PR DESCRIPTION
Typically when more than 2000 records are returned, Salesforce will provide a nextRecordsUrl parameter that shall be used to retrieve the next batch. `query` and `queryAll` functions now recursively query  until Salesforce tells that it's done.

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_query.htm

`query` and `query_all` have been refactored into a single line function calling `query_with` which use either `query` or `queryAll` parameter.

`async-recursion` has been added to the crates which hides the implementation details (dyn Box Future etc.)

However along `DeserializeOwned`, the `Send` trait to ensure thread safety must now be added when querying, so this is a breaking change, albeit mostly transparent.